### PR TITLE
🐛 Afficher le discriminant discord seulement si l'utilisateur en possède un.

### DIFF
--- a/mp2i/cogs/commands.py
+++ b/mp2i/cogs/commands.py
@@ -114,10 +114,10 @@ class Commands(Cog):
         content = ""
         for member in ctx.guild.members:
             if discord.utils.get(member.roles, name="Référent"):
-                content += (
-                    f"- {member.nick} (`{member.name}#{member.discriminator}`"
-                    f" - {member.status})\n"
-                )
+                content += f"- {member.nick} (`{member.name}"
+                if member.disciminator != 0:
+                    content += f"#{member.discriminator}"
+                content += f"` - {member.status})\n"
         embed = discord.Embed(
             title=f"Liste des étudiants référents du serveur {ctx.guild.name}",
             colour=0xFF66FF,


### PR DESCRIPTION
Mise à jour de la commande `referents` faisant suite à l'annonce de Discord de la suppression des discriminants.
Voici une image du rendu actuel pour un discriminant inexistant :
![DiscordCanary_kSUdDt5DHD](https://github.com/prepas-mp2i/mp2i-discord-bot/assets/44125445/34fd02f0-77ee-4fc1-9975-35964186027c)

Cette PR vise à supprimer la partie devenue inutile, ie `#0`.