### PR TITLE
Add leaderboard command

### DIFF
--- a/mp2i/wrappers/member.py
+++ b/mp2i/wrappers/member.py
@@ -32,6 +32,9 @@ class MemberWrapper:
     def __getattr__(self, name: str):
         return getattr(self.member, name)
 
+    def __eq__(self, member):
+        return self.id == member.id
+
     @classmethod
     async def convert(cls, ctx, member):
         member = await MemberConverter().convert(ctx, member)


### PR DESCRIPTION
Ajout d'une commande leaderboard pour afficher un classement des membres d'un serveur sur la base du nombre de messages.
Ajout d'une surcharge de méthode __eq__ dans le modèle MemberModel pour pouvoir trouver l'indice de manière plus concise.