### PR TITLE
Update leaderboard command

### DIFF
--- a/mp2i/cogs/commands.py
+++ b/mp2i/cogs/commands.py
@@ -200,29 +200,31 @@ class Commands(Cog):
         Parameters
         ----------
         rmax : int
-            Rang maximal.
+            Rang maximal (compris entre 0 et 100)
         """
 
         def filtered_members(ctx):
             for member in map(MemberWrapper, ctx.guild.members):
                 if (not member.bot) and member.exists():
                     yield member
-
-        members = sorted(
-            filtered_members(ctx), key=attrgetter("messages_count"), reverse=True
-        )
-        author = MemberWrapper(ctx.author)
-        rank = members.index(author) + 1
-        content = f"→ {rank}. **{author.name}** : {author.messages_count} messages\n\n"
-        for r, member in enumerate(members[:rmax], 1):
-            content += f"{r}. **{member.name}** : {member.messages_count} messages\n"
-
-        embed = discord.Embed(
-            colour=0x2BFAFA,
-            title=f"Top {rmax} des membres du serveur",
-            description=content,
-        )
-        await ctx.send(embed=embed)
+        if rmax <= 100 and rmax >= 0:
+            members = sorted(
+                filtered_members(ctx), key=attrgetter("messages_count"), reverse=True
+            )
+            author = MemberWrapper(ctx.author)
+            rank = members.index(author) + 1
+            content = f"→ {rank}. **{author.name}** : {author.messages_count} messages\n\n"
+            for r, member in enumerate(members[:rmax], 1):
+                content += f"{r}. **{member.name}** : {member.messages_count} messages\n"
+    
+            embed = discord.Embed(
+                colour=0x2BFAFA,
+                title=f"Top {rmax} des membres du serveur",
+                description=content,
+            )
+            await ctx.send(embed=embed)
+        else :
+            await ctx.reply("rmax doit être un nombre compris entre 0 et 100", ephemeral=True)
 
     @Cog.listener("on_message")
     async def unbinarize(self, msg: discord.Message):

--- a/mp2i/cogs/commands.py
+++ b/mp2i/cogs/commands.py
@@ -193,6 +193,7 @@ class Commands(Cog):
         await ctx.send(embed=embed)
 
     @hybrid_command(name="leaderboard")
+    @guild_only()
     async def leaderboard(self, ctx, rmax: Optional[int] = 10):
         """
         Affiche le classement des membres par nombre de messages.


### PR DESCRIPTION
Pour éviter de mettre des nombres négatifs et de mettre des nombres trop grand pour le paramètre rmax dans le leaderborad
Je pense en effet que au dessus de 100 personnes dans le top ça ne sert plus à rien et ça risque de polluer le salon avec un message beaucoup trop long -> à changer si nécessaire

Avec un nombre négatif : 
![image](https://github.com/prepas-mp2i/mp2i-discord-bot/assets/61625831/7a46b448-e5c4-4239-b208-14f7d66c9342)
