### PR TITLE
Ajout de la possibilité de choisir son lycée 

### DIFF
--- a/mp2i/cogs/commands.py
+++ b/mp2i/cogs/commands.py
@@ -113,6 +113,8 @@ class Commands(Cog):
         embed.set_thumbnail(url=member.avatar.url)
         embed.add_field(name="Pseudo", value=member.mention)
         embed.add_field(name="Membre depuis", value=f"{member.joined_at:%d/%m/%Y}")
+        if member.lycee != "Aucun":
+            embed.add_field(name="Lycée", value=member.lycee)
         embed.add_field(name="Messages", value=member.messages_count)
         embed.add_field(
             name="Rôles",

--- a/mp2i/cogs/commands.py
+++ b/mp2i/cogs/commands.py
@@ -1,8 +1,8 @@
 import re
 import logging
 from typing import Optional
-from datetime import datetime
-from operator import attrgetter, itemgetter
+
+from operator import attrgetter
 
 import discord
 from discord.ext.commands import Cog, hybrid_command, guild_only, has_permissions
@@ -13,8 +13,6 @@ from mp2i.wrappers.member import MemberWrapper
 from mp2i.utils import youtube
 
 logger = logging.getLogger(__name__)
-
-PREPA_REGEX = re.compile(r"^.+[|@] *(?P<prepa>.*)$")
 
 
 class Commands(Cog):
@@ -113,8 +111,8 @@ class Commands(Cog):
         embed.set_thumbnail(url=member.avatar.url)
         embed.add_field(name="Pseudo", value=member.mention)
         embed.add_field(name="Membre depuis", value=f"{member.joined_at:%d/%m/%Y}")
-        if member.lycee != "Aucun":
-            embed.add_field(name="Lycée", value=member.lycee)
+        if member.school != "Aucun":
+            embed.add_field(name="Lycée", value=member.school)
         embed.add_field(name="Messages", value=member.messages_count)
         embed.add_field(
             name="Rôles",
@@ -160,41 +158,6 @@ class Commands(Cog):
                 number = len(guild.get_role(role_cfg.id).members)
                 emoji = guild.get_emoji_by_name(role_cfg.emoji)
                 embed.add_field(name=f"{emoji} {role_name}", value=number)
-        await ctx.send(embed=embed)
-
-    @hybrid_command(name="referents")
-    @guild_only()
-    async def referents(self, ctx) -> None:
-        """
-        Liste les étudiants référents du serveur.
-        """
-        guild = GuildWrapper(ctx.guild)
-        referent_role = guild.get_role_by_qualifier("Référent")
-        if referent_role is None:
-            await logger.warning("No referent role in bot config file.")
-
-        referents = []
-        for member in guild.members:
-            if not member.get_role(referent_role.id):
-                continue
-            member_db = MemberWrapper(member)
-            if member_db.exists() and member_db.lycee != "Aucun":
-                referents.append((member, member_db.lycee))
-            elif match := PREPA_REGEX.match(member.nick):
-                referents.append((member, match.group(1)))
-
-        content = ""
-        for member, prepa in sorted(referents, key=itemgetter(1)):
-            status = guild.get_emoji_by_name(f"{member.status}")
-            content += f"- **{prepa}** : `{str(member)}`・{member.mention} {status}\n"
-
-        embed = discord.Embed(
-            title=f"Liste des étudiants référents du serveur {guild.name}",
-            colour=0xFF66FF,
-            description=content,
-            timestamp=datetime.now(),
-        )
-        embed.set_footer(text=self.bot.user.name)
         await ctx.send(embed=embed)
 
     @hybrid_command(name="leaderboard")

--- a/mp2i/cogs/commands.py
+++ b/mp2i/cogs/commands.py
@@ -177,7 +177,10 @@ class Commands(Cog):
         for member in guild.members:
             if not member.get_role(referent_role.id):
                 continue
-            if match := PREPA_REGEX.match(member.nick):
+            member_db = MemberWrapper(member)
+            if member_db.exists() and member_db.lycee != "Aucun":
+                referents.append((member, member_db.lycee))
+            elif match := PREPA_REGEX.match(member.nick):
                 referents.append((member, match.group(1)))
 
         content = ""

--- a/mp2i/cogs/lycee.py
+++ b/mp2i/cogs/lycee.py
@@ -1,0 +1,51 @@
+import logging
+
+import discord
+from discord.ext.commands import Cog, hybrid_command, guild_only, has_permissions
+from discord import app_commands
+from typing import List
+
+from mp2i import STATIC_DIR
+from mp2i.utils import database
+from mp2i.wrappers.member import MemberWrapper
+from mp2i.wrappers.guild import GuildWrapper
+
+logger = logging.getLogger(__name__)
+
+
+class Lycee(Cog):
+    """
+    DESCRIPTION
+    """
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    async def choices_lycee(
+        self, interaction: discord.Interaction, current: str
+    ) -> List[app_commands.Choice[str]]:
+        with open(STATIC_DIR / "text/Liste_lycee_MP2I.txt") as f:
+            lycees = f.read().splitlines()
+        return [
+            app_commands.Choice(name=choice, value=choice)
+            for choice in lycees
+            if current.lower() in choice.lower()
+        ]
+
+    @hybrid_command(name="choixlycee")
+    @guild_only
+    @app_commands.autocomplete(item=choices_lycee)
+    async def choix_lycee(self, interaction: discord.Interaction, lycee: str):
+        with open(STATIC_DIR / "text/Liste_lycee_MP2I.txt") as f:
+            lycees = f.read().splitlines()
+        if not lycee in lycees:
+            await interaction.response.send_message("Le nom du lycée n'est pas valide")
+            return
+        member = MemberWrapper(interaction.user)
+        if not member.exists():
+            logger.warning(f"The user {member.name} was not a registered member")
+            member.register()
+        member.lycee = lycee
+        await interaction.response.send_message(
+            f"Vous faites maintenant partie du lycée {lycee}"
+        )

--- a/mp2i/cogs/lycee.py
+++ b/mp2i/cogs/lycee.py
@@ -1,7 +1,13 @@
 import logging
 
 import discord
-from discord.ext.commands import Cog, hybrid_command, guild_only, has_any_role
+from discord.ext.commands import (
+    Cog,
+    hybrid_command,
+    guild_only,
+    has_any_role,
+    has_permissions,
+)
 from discord import app_commands
 from typing import List
 
@@ -56,6 +62,37 @@ class Lycee(Cog):
             member.lycee = lycee
             await ctx.reply(
                 f"Vous faites maintenant partie du lycée {lycee}", ephemeral=True
+            )
+
+    @hybrid_command(name="chooselyceeforuser")
+    @guild_only()
+    @has_permissions(manage_messages=True)
+    @app_commands.autocomplete(lycee=autocomplete_lycee)
+    async def choose_lycee_for_user(self, ctx, user: discord.Member, lycee: str):
+        """
+        Associe un lycée à un membre (Aucun pour supprimer l'association)
+
+        Parameters
+        ----------
+        user : discord.Member
+            Le membre à associer avec le lycée
+        lycee : str
+            Le lycée à associer
+        """
+        if not lycee in self.lycees and lycee != "Aucun":
+            await ctx.reply("Le nom du lycée n'est pas valide", ephemeral=True)
+            return
+        member = MemberWrapper(user)
+        if lycee == "Aucun":
+            member.lycee = None
+            await ctx.reply(
+                "{user.mention} ne fait plus partie aucun lycée", ephemeral=True
+            )
+        else:
+            member.lycee = lycee
+            await ctx.reply(
+                f"{user.mention} fait maintenant partie du lycée {lycee}",
+                ephemeral=True,
             )
 
     @hybrid_command(name="lycees")

--- a/mp2i/cogs/lycee.py
+++ b/mp2i/cogs/lycee.py
@@ -20,22 +20,22 @@ class Lycee(Cog):
 
     def __init__(self, bot):
         self.bot = bot
+        with open(STATIC_DIR / "text/Liste_lycee_MP2I.txt") as f:
+            self.lycees = f.read().splitlines()
 
-    async def choices_lycee(
+    async def autocomplete_lycee(
         self, interaction: discord.Interaction, current: str
     ) -> List[app_commands.Choice[str]]:
-        with open(STATIC_DIR / "text/Liste_lycee_MP2I.txt") as f:
-            lycees = f.read().splitlines()
         return [
             app_commands.Choice(name=choice, value=choice)
-            for choice in lycees
+            for choice in self.lycees
             if current.lower() in choice.lower()
         ]
 
-    @hybrid_command(name="choixlycee")
+    @hybrid_command(name="chooselycee")
     @guild_only
-    @app_commands.autocomplete(item=choices_lycee)
-    async def choix_lycee(self, interaction: discord.Interaction, lycee: str):
+    @app_commands.autocomplete(item=autocomplete_lycee)
+    async def choose_lycee(self, interaction: discord.Interaction, lycee: str):
         """
         Associe un lycée à soi-même
 
@@ -44,9 +44,7 @@ class Lycee(Cog):
         lycee : str
             Le lycée à associer
         """
-        with open(STATIC_DIR / "text/Liste_lycee_MP2I.txt") as f:
-            lycees = f.read().splitlines()
-        if not lycee in lycees:
+        if not lycee in self.lycees:
             await interaction.response.send_message("Le nom du lycée n'est pas valide")
             return
         member = MemberWrapper(interaction.user)

--- a/mp2i/cogs/lycee.py
+++ b/mp2i/cogs/lycee.py
@@ -1,7 +1,13 @@
 import logging
 
 import discord
-from discord.ext.commands import Cog, hybrid_command, guild_only, has_permissions
+from discord.ext.commands import (
+    Cog,
+    hybrid_command,
+    guild_only,
+    has_permissions,
+    command,
+)
 from discord import app_commands
 from typing import List
 
@@ -20,7 +26,7 @@ class Lycee(Cog):
 
     def __init__(self, bot):
         self.bot = bot
-        with open(STATIC_DIR / "text/Liste_lycee_MP2I.txt") as f:
+        with open(STATIC_DIR / "text/Liste_lycee_MP2I.txt", encoding="UTF-8") as f:
             self.lycees = f.read().splitlines()
 
     async def autocomplete_lycee(
@@ -35,7 +41,7 @@ class Lycee(Cog):
     @hybrid_command(name="chooselycee")
     @guild_only()
     @app_commands.autocomplete(lycee=autocomplete_lycee)
-    async def choose_lycee(self, interaction: discord.Interaction, lycee: str):
+    async def choose_lycee(self, ctx, lycee: str):
         """
         Associe un lycée à soi-même
 
@@ -45,15 +51,12 @@ class Lycee(Cog):
             Le lycée à associer
         """
         if not lycee in self.lycees:
-            await interaction.response.send_message("Le nom du lycée n'est pas valide")
+            await ctx.reply("Le nom du lycée n'est pas valide", ephemeral=True)
             return
-        member = MemberWrapper(interaction.user)
-        if not member.exists():
-            logger.warning(f"The user {member.name} was not a registered member")
-            member.register()
+        member = MemberWrapper(ctx.author)
         member.lycee = lycee
-        await interaction.response.send_message(
-            f"Vous faites maintenant partie du lycée {lycee}"
+        await ctx.reply(
+            f"Vous faites maintenant partie du lycée {lycee}", ephemeral=True
         )
 
 

--- a/mp2i/cogs/lycee.py
+++ b/mp2i/cogs/lycee.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class Lycee(Cog):
     """
-    DESCRIPTION
+    Association d'un membre et d'un lycée
     """
 
     def __init__(self, bot):
@@ -36,6 +36,14 @@ class Lycee(Cog):
     @guild_only
     @app_commands.autocomplete(item=choices_lycee)
     async def choix_lycee(self, interaction: discord.Interaction, lycee: str):
+        """
+        Associe un lycée à soi-même
+
+        Parameters
+        ----------
+        lycee : str
+            Le lycée à associer
+        """
         with open(STATIC_DIR / "text/Liste_lycee_MP2I.txt") as f:
             lycees = f.read().splitlines()
         if not lycee in lycees:

--- a/mp2i/cogs/lycee.py
+++ b/mp2i/cogs/lycee.py
@@ -33,8 +33,8 @@ class Lycee(Cog):
         ]
 
     @hybrid_command(name="chooselycee")
-    @guild_only
-    @app_commands.autocomplete(item=autocomplete_lycee)
+    @guild_only()
+    @app_commands.autocomplete(lycee=autocomplete_lycee)
     async def choose_lycee(self, interaction: discord.Interaction, lycee: str):
         """
         Associe un lycée à soi-même
@@ -55,3 +55,7 @@ class Lycee(Cog):
         await interaction.response.send_message(
             f"Vous faites maintenant partie du lycée {lycee}"
         )
+
+
+async def setup(bot) -> None:
+    await bot.add_cog(Lycee(bot))

--- a/mp2i/cogs/school.py
+++ b/mp2i/cogs/school.py
@@ -1,4 +1,8 @@
+import re
 import logging
+
+from datetime import datetime
+from operator import itemgetter
 
 import discord
 from discord.ext.commands import (
@@ -6,9 +10,9 @@ from discord.ext.commands import (
     hybrid_command,
     guild_only,
     has_any_role,
-    has_permissions,
 )
 from discord import app_commands
+
 from typing import List, Optional
 
 from mp2i import STATIC_DIR
@@ -16,10 +20,14 @@ from mp2i.utils import database
 from mp2i.wrappers.member import MemberWrapper
 from mp2i.wrappers.guild import GuildWrapper
 
+from collections import Counter
+
+PREPA_REGEX = re.compile(r"^.+[|@] *(?P<prepa>.*)$")
+
 logger = logging.getLogger(__name__)
 
 
-class Lycee(Cog):
+class School(Cog):
     """
     Association d'un membre et d'un lycée
     """
@@ -27,49 +35,49 @@ class Lycee(Cog):
     def __init__(self, bot):
         self.bot = bot
         with open(STATIC_DIR / "text/Liste_lycee_MP2I.txt", encoding="UTF-8") as f:
-            self.lycees = f.read().splitlines()
+            self.schools = f.read().splitlines()
 
-    async def autocomplete_lycee(
+    async def autocomplete_school(
         self, interaction: discord.Interaction, current: str
     ) -> List[app_commands.Choice[str]]:
         return [
             app_commands.Choice(name=choice, value=choice)
-            for choice in self.lycees
+            for choice in self.schools
             if current.lower() in choice.lower()
         ]
 
-    @hybrid_command(name="chooselycee")
+    @hybrid_command(name="chooseschool")
     @guild_only()
     @has_any_role("MP2I", "MPI", "Ex MPI", "Moderateur", "Administrateur")
-    @app_commands.autocomplete(lycee=autocomplete_lycee)
-    async def choose_lycee(
-        self, ctx, lycee: str, user: Optional[discord.Member] = None
+    @app_commands.autocomplete(school=autocomplete_school)
+    async def choose_school(
+        self, ctx, school: str, user: Optional[discord.Member] = None
     ):
         """
         Associe un lycée à un membre (Aucun pour supprimer l'association)
 
         Parameters
         ----------
-        lycee : str
+        school : str
             Le lycée à associer
         user : Optional[discord.Member]
             Réservé aux modérateurs
             L'utilisateur à qui on associe le lycéee (avec soi-même l'argument est vide)
         """
-        if not lycee in self.lycees and lycee != "Aucun":
+        if not school in self.schools and school != "Aucun":
             await ctx.reply("Le nom du lycée n'est pas valide", ephemeral=True)
             return
         if user is None or user == ctx.author:
             member = MemberWrapper(ctx.author)
-            if lycee == "Aucun":
-                member.lycee = None
+            if school == "Aucun":
+                member.school = None
                 await ctx.reply(
                     "Vous ne faites plus partie aucun lycée", ephemeral=True
                 )
             else:
-                member.lycee = lycee
+                member.school = school
                 await ctx.reply(
-                    f"Vous faites maintenant partie du lycée {lycee}", ephemeral=True
+                    f"Vous faites maintenant partie du lycée {school}", ephemeral=True
                 )
         else:
             if any(
@@ -80,15 +88,15 @@ class Lycee(Cog):
                 ]
             ):
                 member = MemberWrapper(user)
-                if lycee == "Aucun":
-                    member.lycee = None
+                if school == "Aucun":
+                    member.school = None
                     await ctx.reply(
                         "{user.mention} ne fait plus partie aucun lycée", ephemeral=True
                     )
                 else:
-                    member.lycee = lycee
+                    member.school = school
                     await ctx.reply(
-                        f"{user.mention} fait maintenant partie du lycée {lycee}",
+                        f"{user.mention} fait maintenant partie du lycée {school}",
                         ephemeral=True,
                     )
             else:
@@ -97,25 +105,19 @@ class Lycee(Cog):
                     ephemeral=True,
                 )
 
-    @hybrid_command(name="lycees")
+    @hybrid_command(name="schools")
     @guild_only()
-    async def lycees(self, ctx):
+    async def schools(self, ctx):
         """
         Affiche le nombre de étudiants étant ou ayant été en MP2I/MPI réparti par lycée
         """
-        def members_lycee(ctx):
-            for member in map(MemberWrapper, ctx.guild.members):
-                if (not member.bot) and member.exists() and member.lycee != "Aucun":
-                    yield member.lycee
-
-        count = dict((i, 0) for i in self.lycees)
-        for m in members_lycee(ctx):
-            count[m] += 1
+        school_members = map(lambda m: MemberWrapper(m).school, ctx.guild.members)
+        school_count = Counter(school_members)
         content = ""
-        for lycee, nb_studient in count.items():
-            plural = "s" if nb_studient > 1 else ""
-            if nb_studient > 0:
-                content += f"**{lycee}** : {nb_studient} étudiant{plural}\n"
+        for school, nb_student in school_count.items():
+            plural = "s" if nb_student > 1 else ""
+            if nb_student > 0 and school != "Aucun":
+                content += f"**{school}** : {nb_student} étudiant{plural}\n"
         title = "Nombre de membres du serveur par lycée"
         embed = discord.Embed(
             colour=0x2BFAFA,
@@ -124,6 +126,41 @@ class Lycee(Cog):
         )
         await ctx.send(embed=embed)
 
+    @hybrid_command(name="referents")
+    @guild_only()
+    async def referents(self, ctx) -> None:
+        """
+        Liste les étudiants référents du serveur.
+        """
+        guild = GuildWrapper(ctx.guild)
+        referent_role = guild.get_role_by_qualifier("Référent")
+        if referent_role is None:
+            await logger.warning("No referent role in bot config file.")
+
+        referents = []
+        for member in guild.members:
+            if not member.get_role(referent_role.id):
+                continue
+            member_db = MemberWrapper(member)
+            if member_db.exists() and member_db.school != "Aucun":
+                referents.append((member, member_db.school))
+            elif match := PREPA_REGEX.match(member.nick):
+                referents.append((member, match.group(1)))
+
+        content = ""
+        for member, prepa in sorted(referents, key=itemgetter(1)):
+            status = guild.get_emoji_by_name(f"{member.status}")
+            content += f"- **{prepa}** : `{str(member)}`・{member.mention} {status}\n"
+
+        embed = discord.Embed(
+            title=f"Liste des étudiants référents du serveur {guild.name}",
+            colour=0xFF66FF,
+            description=content,
+            timestamp=datetime.now(),
+        )
+        embed.set_footer(text=self.bot.user.name)
+        await ctx.send(embed=embed)
+
 
 async def setup(bot) -> None:
-    await bot.add_cog(Lycee(bot))
+    await bot.add_cog(School(bot))

--- a/mp2i/models.py
+++ b/mp2i/models.py
@@ -26,7 +26,7 @@ class MemberModel(Base):
     role: str = Column(String(50), nullable=True)
     messages_count: int = Column(Integer, default=0)
     profile_color: str = Column(String(8), nullable=True)
-    lycee: str = Column(String(50), nullable=True, default=None)
+    school: str = Column(String(50), nullable=True, default=None)
 
     def __repr__(self):
         return f"Member(id={self.id}, name={self.name}, role={self.role})"

--- a/mp2i/models.py
+++ b/mp2i/models.py
@@ -26,6 +26,7 @@ class MemberModel(Base):
     role: str = Column(String(50), nullable=True)
     messages_count: int = Column(Integer, default=0)
     profile_color: str = Column(String(8), nullable=True)
+    lycee: str = Column(String(50), nullable=True, default=None)
 
     def __repr__(self):
         return f"Member(id={self.id}, name={self.name}, role={self.role})"

--- a/mp2i/static/text/Liste_lycee_MP2I.txt
+++ b/mp2i/static/text/Liste_lycee_MP2I.txt
@@ -1,0 +1,40 @@
+Alain René Lesage
+Alfred Kastler
+aux Lazaristes
+Berthollet
+Camille Guérin
+Carnot
+Centre International de Valbonne
+Champollion
+Charles Coëffin
+Claude Bernard 
+Claude Fauriel
+Clémenceau
+Colbert
+Descartes
+Faidherbe
+Fénelon Sainte-Marie
+Fermat
+Franklin Roosevelt
+Frédéric Ozanam
+Gay-Lussac
+Guy Mollet
+Henri Poincaré
+Henri Wallon
+Hoche
+Janson de Sailly
+Jean XXIII 
+Joffre
+Kléber
+La Fayette
+La Martinière Monplaisir
+Le Parc
+Leconte de Lisle
+Louis Le Grand
+Louis Thuillier
+Montaigne
+Paul Valéry
+Pierre Corneille
+Saint-Louis
+Thiers
+Victor Hugo

--- a/mp2i/static/text/Liste_lycee_MP2I.txt
+++ b/mp2i/static/text/Liste_lycee_MP2I.txt
@@ -1,6 +1,6 @@
 Alain René Lesage
 Alfred Kastler
-aux Lazaristes
+Aux Lazaristes
 Berthollet
 Camille Guérin
 Carnot

--- a/mp2i/wrappers/member.py
+++ b/mp2i/wrappers/member.py
@@ -78,7 +78,7 @@ class MemberWrapper:
                 guild_id=self.guild.id,
                 name=self.member.name,
                 role=qualifier,
-                lycee=None,
+                school=None,
             )
         )
         self.__model = self._fetch()  # Update the model
@@ -108,9 +108,9 @@ class MemberWrapper:
         self.update(profile_color=value)
 
     @property
-    def lycee(self) -> str:
-        return self.__model.lycee or "Aucun"
+    def school(self) -> str:
+        return self.__model.school or "Aucun"
 
-    @lycee.setter
-    def lycee(self, value: str):
-        return self.update(lycee=value)
+    @school.setter
+    def school(self, value: str):
+        return self.update(school=value)

--- a/mp2i/wrappers/member.py
+++ b/mp2i/wrappers/member.py
@@ -78,6 +78,7 @@ class MemberWrapper:
                 guild_id=self.guild.id,
                 name=self.member.name,
                 role=qualifier,
+                lycee=None,
             )
         )
         self.__model = self._fetch()  # Update the model
@@ -105,3 +106,11 @@ class MemberWrapper:
     @profile_color.setter
     def profile_color(self, value: str):
         self.update(profile_color=value)
+
+    @property
+    def lycee(self) -> str:
+        return self.__model.lycee or "Aucun"
+
+    @lycee.setter
+    def lycee(self, value: str):
+        return self.update(lycee=value)


### PR DESCRIPTION
Modification de la base de donnée : 
- Ajout d'un attribut lycee pour les membres du discord
Ajout et modifications des commandes : 
- `chooselycee` : associe un lycée qui possède une MP2I avec celui qui utilise la commande
- 'profile' : affiche le lycee qui est associé

Futures améliorations (mais il est préférable de tester si ça marche avant de rajouter des améliorations):
- [x] Modification de la commande `referents` :  affichage du lycée associé plutôt que ce qui est après le @
- [x] Limitation de l'utilisation de la commande 'chooselycee' uniquement aux MP2I/MPI/ex-MPI
- [x] Ajout d'une commande `updatelycee` (nom non définitif) accessible uniquement pour les administrateurs permettant de changer le lycée d'autres personnes
- [x] Modification de `chooselycee` pour permettre de retirer l'association avec un lycée
- [x] Ajout de la commande `lycees` : pour chaque lycée, affichage du nombre de personnes s'étant associé avec lui

Edit : les tests ont été effectués