### PR TITLE
Crée un décorateur personnalisé pour has_any_role

### DIFF
--- a/mp2i/cogs/commands.py
+++ b/mp2i/cogs/commands.py
@@ -220,6 +220,13 @@ class Commands(Cog):
         embed = discord.Embed(colour=0x2BFAFA, title=title, description=content)
         await ctx.send(embed=embed)
 
+    @hybrid_command(name="g")
+    @has_any_role("Gestion Association")
+    async def g(self, ctx) -> None:
+        """
+        Commande réservée aux membres du rôle Gestion Association.
+        """
+        await ctx.send("Vous avez le rôle Gestion Association.")
 
 async def setup(bot) -> None:
     await bot.add_cog(Commands(bot))

--- a/mp2i/cogs/commands.py
+++ b/mp2i/cogs/commands.py
@@ -4,12 +4,12 @@ from typing import Optional
 from operator import attrgetter
 
 import discord
-from discord.ext.commands import Cog, hybrid_command, guild_only, has_permissions, has_any_role
+from discord.ext.commands import Cog, hybrid_command, guild_only, has_permissions
 
 from mp2i.wrappers.guild import GuildWrapper
 from mp2i.wrappers.member import MemberWrapper
 from mp2i.utils import youtube
-from mp2i.utils.discord import defer
+from mp2i.utils.discord import defer, has_any_role
 
 logger = logging.getLogger(__name__)
 

--- a/mp2i/cogs/commands.py
+++ b/mp2i/cogs/commands.py
@@ -220,13 +220,5 @@ class Commands(Cog):
         embed = discord.Embed(colour=0x2BFAFA, title=title, description=content)
         await ctx.send(embed=embed)
 
-    @hybrid_command(name="g")
-    @has_any_role("Gestion Association")
-    async def g(self, ctx) -> None:
-        """
-        Commande réservée aux membres du rôle Gestion Association.
-        """
-        await ctx.send("Vous avez le rôle Gestion Association.")
-
 async def setup(bot) -> None:
     await bot.add_cog(Commands(bot))

--- a/mp2i/cogs/errors.py
+++ b/mp2i/cogs/errors.py
@@ -29,6 +29,14 @@ class ErrorHandler(Cog):
 
         elif hasattr(error, "handled"):
             logger.debug(f"Local error handler for {ctx.command} has been called")
+        
+        elif isinstance(error, errors.MissingAnyRole):
+            logger.debug(f"{error}")
+            await ctx.reply("Vous n'avez pas la permission d'utiliser cette commande.")
+
+        elif isinstance(error, errors.NoPrivateMessage):
+            logger.debug(f"{error}")
+            await ctx.reply("Cette commande ne peut pas être utilisée en message privé.")
 
         elif not isinstance(error, errors.CommandNotFound):
             logger.error(f"{error}")

--- a/mp2i/cogs/sanctions.py
+++ b/mp2i/cogs/sanctions.py
@@ -3,11 +3,12 @@ from datetime import datetime
 from typing import Optional
 
 import discord
-from discord.ext.commands import Cog, hybrid_command, guild_only, has_any_role
+from discord.ext.commands import Cog, hybrid_command, guild_only
 from sqlalchemy import insert, select, delete
 
 from mp2i.utils import database
 from mp2i.models import SanctionModel
+from mp2i.utils.discord import has_any_role
 
 logger = logging.getLogger(__name__)
 

--- a/mp2i/cogs/schools.py
+++ b/mp2i/cogs/schools.py
@@ -7,13 +7,13 @@ from datetime import datetime
 from operator import itemgetter
 
 import discord
-from discord.ext.commands import Cog, hybrid_command, guild_only, has_any_role, Range
+from discord.ext.commands import Cog, hybrid_command, guild_only, Range
 from discord.app_commands import autocomplete, Choice, choices
 
 from mp2i import STATIC_DIR
 from mp2i.wrappers.member import MemberWrapper
 from mp2i.wrappers.guild import GuildWrapper
-from mp2i.utils.discord import defer
+from mp2i.utils.discord import defer, has_any_role
 
 SCHOOL_REGEX = re.compile(r"^.+[|@] *(?P<prepa>.*)$")
 

--- a/mp2i/utils/discord.py
+++ b/mp2i/utils/discord.py
@@ -31,7 +31,7 @@ def has_any_role(*items: str):
         # ctx.guild is None doesn't narrow ctx.author to Member
         guild = GuildWrapper(ctx.guild)
         if any(
-            guild.get_role_by_qualifier(item) is not None and guild.get_role_by_qualifier(item) in ctx.author.roles
+            guild.get_role_by_qualifier(item) in ctx.author.roles
             for item in items
         ):
             return True

--- a/mp2i/utils/discord.py
+++ b/mp2i/utils/discord.py
@@ -31,7 +31,7 @@ def has_any_role(*items: str):
         # ctx.guild is None doesn't narrow ctx.author to Member
         guild = GuildWrapper(ctx.guild)
         if any(
-            guild.get_role_by_qualifier(item) is not None
+            guild.get_role_by_qualifier(item) is not None and guild.get_role_by_qualifier(item) in ctx.author.roles
             for item in items
         ):
             return True

--- a/mp2i/utils/discord.py
+++ b/mp2i/utils/discord.py
@@ -30,8 +30,9 @@ def has_any_role(*items: str):
 
         # ctx.guild is None doesn't narrow ctx.author to Member
         guild = GuildWrapper(ctx.guild)
+        roles_id = {role.id for role in ctx.author.roles}
         if any(
-            guild.get_role_by_qualifier(item) in ctx.author.roles
+            guild.get_role_by_qualifier(item) is not None and guild.get_role_by_qualifier(item).id in roles_id
             for item in items
         ):
             return True

--- a/mp2i/utils/discord.py
+++ b/mp2i/utils/discord.py
@@ -1,5 +1,8 @@
 from functools import wraps
+from discord.ext.commands.errors import NoPrivateMessage, MissingAnyRole
+from discord.ext.commands import check
 
+from mp2i.wrappers.guild import GuildWrapper
 
 def defer(ephemeral: bool = False):
     """
@@ -15,3 +18,23 @@ def defer(ephemeral: bool = False):
         return command_wrapper
 
     return decorator
+
+def has_any_role(*items: str):
+    """
+    Decorator that check if the user has any of the specified roles.
+    """
+
+    def predicate(ctx):
+        if ctx.guild is None:
+            raise NoPrivateMessage()
+
+        # ctx.guild is None doesn't narrow ctx.author to Member
+        guild = GuildWrapper(ctx.guild)
+        if any(
+            guild.get_role_by_qualifier(item) is not None
+            for item in items
+        ):
+            return True
+        raise MissingAnyRole(list(items))
+
+    return check(predicate)


### PR DESCRIPTION
Le décorateur compare maintenant les rôles avec le `bot-config.yaml`, donc si on change le nom du rôle sur Discord, cela n'a aucune influence sur le bot.

Les erreurs sont plus personnalisées en fonction de l'erreur.