### PR TITLE
Ajout d'un contrôleur de santé pour la base de données.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,5 +83,5 @@ Run the command `python3 -m mp2i` on Linux or `py -m mp2i` on Windows.
 - ### Using Docker
 
 ```sh
-docker-compose up --build
+docker compose up --build
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,12 @@ services:
       - POSTGRES_PASSWORD=root
 #    ports:
 #      - "2345:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d MP2I"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
 
   bot:
     container_name: MP2I_Bot
@@ -22,4 +28,6 @@ services:
       ENVIRONMENT: development
       DATABASE_URL: postgresql+psycopg2://root:root@postgres:5432/MP2I
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+        restart: true


### PR DESCRIPTION
L'utilisation d'un contrôleur de santé permet entre autres d'être sûr que le bot ne tente pas de se connecter à la base de données avant que celle-ci ne soit pleinement opérationnel. Ce cas de figure peut arriver lorsque la base de données se génère, id est au premier `up` du `docker compose`.

La Pull Request propose également de changer la commande `docker-compose` du README.md en `docker compose`. En effet, `docker compose` est la commande privilégiée par Docker puisque plus récente que `docker-compose` qui peut être souvent très en retard.