### PR TITLE
Refonte du système de suggestions

### DIFF
--- a/bot-config.yaml.example
+++ b/bot-config.yaml.example
@@ -63,7 +63,6 @@ guilds:
         emoji: association
         choice: false
     channels:
-      suggestion: 940718694357676042
       website: 911609939728949309
       log: 0
       admin: 0
@@ -129,7 +128,6 @@ guilds:
         emoji: association
         choice: false
     channels:
-      suggestion: 939262782073897053
       website: 939262782342303796
       log: 0
       admin: 0

--- a/mp2i/cogs/pinnable.py
+++ b/mp2i/cogs/pinnable.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+
+import discord
+from discord.ext.commands import Cog, guild_only
+
+from mp2i.wrappers.guild import GuildWrapper
+
+
+class Pinnable(Cog):
+
+    MINIMUM_PINS = 5
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @Cog.listener("on_raw_reaction_add")
+    @guild_only()
+    async def add_pin(self, payload) -> None:
+        """
+        Add a pin to a message and send it to website channel when
+        it reach the required number of pins reactions.
+        """
+        if str(payload.emoji) != "📌":
+            return
+
+        channel = self.bot.get_channel(payload.channel_id)
+        message = await channel.fetch_message(payload.message_id)
+        pins = discord.utils.get(message.reactions, emoji="📌", me=False)
+        if pins is None or pins.count < self.MINIMUM_PINS:
+            return
+
+        author = message.author
+        embed = discord.Embed(
+            colour=0x00FF00,
+            title="Message épinglé",
+            description="Un message a été retenu par la communauté, vous pouvez "
+                        "probablement l'ajouter dans la [FAQ](https://prepas-mp2i.fr/faq/).",
+            timestamp=datetime.now(),
+        )
+        embed.add_field(name="Lien du message", value=message.jump_url)
+        embed.set_author(name=author.name, icon_url=author.avatar.url)
+        embed.set_footer(text=self.bot.user.name)
+        website_chan = self.bot.get_channel(
+            GuildWrapper(channel.guild).config.channels.website
+        )
+        await website_chan.send(embed=embed)
+        # Pour ne pas envoyer le message plusieurs fois
+        await message.add_reaction("📌")
+
+
+async def setup(bot) -> None:
+    await bot.add_cog(Pinnable(bot))

--- a/mp2i/cogs/suggestions.py
+++ b/mp2i/cogs/suggestions.py
@@ -16,8 +16,6 @@ class Suggestion(Cog):
     Offers commands to allow members to propose suggestions and interact with them
     """
 
-    MINIMUM_PINS = 5
-
     def __init__(self, bot):
         self.bot = bot
 
@@ -116,40 +114,6 @@ class Suggestion(Cog):
 
         await channel.send(file=file, embed=embed)
         await suggestion.delete()
-
-    @Cog.listener("on_raw_reaction_add")
-    @guild_only()
-    async def add_pin(self, payload) -> None:
-        """
-        Add a pin to a message and send it to website channel when
-        it reach the required number of pins reactions.
-        """
-        if str(payload.emoji) != "📌":
-            return
-
-        channel = self.bot.get_channel(payload.channel_id)
-        message = await channel.fetch_message(payload.message_id)
-        pins = discord.utils.get(message.reactions, emoji="📌", me=False)
-        if pins is None or pins.count < self.MINIMUM_PINS:
-            return
-
-        author = message.author
-        embed = discord.Embed(
-            colour=0x00FF00,
-            title="Message épinglé",
-            description="Un message a été retenu par la communauté, vous pouvez "
-            "probablement l'ajouter dans la [FAQ](https://prepas-mp2i.fr/faq/).",
-            timestamp=datetime.now(),
-        )
-        embed.add_field(name="Lien du message", value=message.jump_url)
-        embed.set_author(name=author.name, icon_url=author.avatar.url)
-        embed.set_footer(text=self.bot.user.name)
-        website_chan = self.bot.get_channel(
-            GuildWrapper(channel.guild).config.channels.website
-        )
-        await website_chan.send(embed=embed)
-        # Pour ne pas envoyer le message plusieurs fois
-        await message.add_reaction("📌")
     
     @hybrid_command(name="suggestions")
     @guild_only()

--- a/mp2i/cogs/suggestions.py
+++ b/mp2i/cogs/suggestions.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Optional
 
 import discord
-from discord import TextStyle, Thread, InteractionResponse, Webhook
+from discord import TextStyle, Thread, Webhook
 from discord.ext.commands import Cog, GroupCog, guild_only, hybrid_command, Context
 from discord.app_commands import Choice, choices
 from discord.ui import Modal, TextInput
@@ -59,7 +59,7 @@ class Suggestion(GroupCog, group_name="suggestions", description="Gestion des su
         with open(STATIC_DIR / "text/suggestions.md", encoding="utf-8") as f:
             content = f.read()
         embed = discord.Embed(
-            title="Fonctionnement des suggestions",
+            title="**Fonctionnement des suggestions**",
             description=content,
             colour=0xFF66FF,
         )

--- a/mp2i/cogs/suggestions.py
+++ b/mp2i/cogs/suggestions.py
@@ -240,7 +240,7 @@ class Suggestion(GroupCog, group_name="suggestions", description="Gestion des su
                     placeholder=
                     "Le vocable chocolatine est à préférer quand le contexte le permet, c'est-à-dire dans tous les cas !",
                     min_length=30,
-                    max_length=1024,
+                    max_length=3072,
                     style=TextStyle.paragraph,
                     required=True
                 )

--- a/mp2i/cogs/suggestions.py
+++ b/mp2i/cogs/suggestions.py
@@ -210,7 +210,7 @@ class Suggestion(GroupCog, group_name="suggestions", description="Gestion des su
         await message.edit(embed=embed)
         database.execute(
             update(SuggestionModel)
-            .where(SuggestionModel.message_id == suggestion.id)
+            .where(SuggestionModel.id == suggestion.id)
             .values(
                 state=new_state.value,
                 handled_by=staff,

--- a/mp2i/cogs/suggestions.py
+++ b/mp2i/cogs/suggestions.py
@@ -208,6 +208,7 @@ class Suggestion(GroupCog, group_name="suggestions", description="Gestion des su
             content += f" Vous retrouverez la raison de cette décision dans le message suivant : {suggestion.to_url()}."
         await thread.send(content)
         await message.edit(embed=embed)
+        await message.clear_reactions()
         database.execute(
             update(SuggestionModel)
             .where(SuggestionModel.id == suggestion.id)

--- a/mp2i/models.py
+++ b/mp2i/models.py
@@ -55,6 +55,9 @@ class SuggestionModel(Base):
             f"Suggestion(author={self.author_id}, title={self.title:30.30}"
         )
 
+    def to_url(self):
+        return f"https://discord.com/channels/{self.guild_id}/{self.channel_id}/{self.message_id}"
+
 
 class SanctionModel(Base):
     __tablename__ = "sanctions"

--- a/mp2i/models.py
+++ b/mp2i/models.py
@@ -12,6 +12,7 @@ class GuildModel(Base):
     name: str = Column(String(50))
     members = relationship("MemberModel", cascade="all, delete")
     roles_message_id: int = Column(BigInteger, unique=True, nullable=True)
+    suggestion_message_id: int = Column(BigInteger, unique=True, nullable=True)
 
     def __repr__(self):
         return f"Guild(id={self.id}, name={self.name})"
@@ -42,12 +43,14 @@ class SuggestionModel(Base):
     guild_id: int = Column(BigInteger, ForeignKey("guilds.id", ondelete="CASCADE"))
     date = Column(DateTime, nullable=True)
     message_id: int = Column(BigInteger, nullable=True, unique=True)
+    channel_id: int = Column(BigInteger, nullable=True)
     state: str = Column(String(50), nullable=False, default="open")
-    description: str = Column(Text)
+    title: str = Column(String(80))
+    description: str = Column(String(1024))
 
     def __repr__(self):
         return (
-            f"Suggestion(author={self.author_id}, description={self.description:30.30}"
+            f"Suggestion(author={self.author_id}, title={self.title:30.30}"
         )
 
 

--- a/mp2i/models.py
+++ b/mp2i/models.py
@@ -46,7 +46,7 @@ class SuggestionModel(Base):
     channel_id: int = Column(BigInteger, nullable=True)
     state: str = Column(String(50), nullable=False, default="open")
     title: str = Column(String(80))
-    description: str = Column(String(1024))
+    description: str = Column(String(3072))
 
     def __repr__(self):
         return (

--- a/mp2i/models.py
+++ b/mp2i/models.py
@@ -47,6 +47,8 @@ class SuggestionModel(Base):
     state: str = Column(String(50), nullable=False, default="open")
     title: str = Column(String(80))
     description: str = Column(String(3072))
+    handled_by: int = Column(BigInteger)
+    handled_time = Column(DateTime, nullable=True)
 
     def __repr__(self):
         return (

--- a/mp2i/static/text/suggestions.md
+++ b/mp2i/static/text/suggestions.md
@@ -1,8 +1,7 @@
 **Vous pouvez proposer ici des suggestions afin d'améliorer le serveur** (nouvelles commandes, nouveaux salons, nouvelles fonctionnalités...)
 
-✅ Voter pour une suggestion
-
+✅ Soutenir une suggestion
 ❌ S'opposer à une suggestion
 
-Voter pour une suggestion donne plus de chances à celle-ci d'être acceptée !
+💡 _Vous serez informé(e) de la décision prise par l'administration au sujet de votre suggestion._
 

--- a/mp2i/static/text/suggestions.md
+++ b/mp2i/static/text/suggestions.md
@@ -6,4 +6,3 @@
 
 Voter pour une suggestion donne plus de chances à celle-ci d'être acceptée !
 
-**Info** : Le vote de l'administrateur est décisif ! Un message sera envoyé dans le salon pour notifier de l'issue d'une suggestion.

--- a/mp2i/wrappers/guild.py
+++ b/mp2i/wrappers/guild.py
@@ -79,12 +79,6 @@ class GuildWrapper:
         return self.guild.get_channel(self.config.channels.log)
 
     @cached_property
-    def suggestion_channel(self) -> Optional[discord.TextChannel]:
-        if not self.config:
-            return None
-        return self.guild.get_channel(self.config.channels.suggestion)
-
-    @cached_property
     def website_channel(self) -> Optional[discord.TextChannel]:
         if not self.config:
             return None
@@ -99,7 +93,15 @@ class GuildWrapper:
     @property
     def roles_message_id(self) -> Optional[int]:
         return self.__model.roles_message_id
-
+    
     @roles_message_id.setter
     def roles_message_id(self, message_id: Optional[int]):
         self.update(roles_message_id=message_id)
+
+    @property
+    def suggestion_message_id(self) -> Optional[int]:
+        return self.__model.suggestion_message_id
+    
+    @suggestion_message_id.setter
+    def suggestion_message_id(self, message_id: Optional[int]):
+        self.update(suggestion_message_id=message_id)


### PR DESCRIPTION
Cette Pull Request propose une refonte profond du système de suggestions. Voici la liste des nouveautés :

- Tout d'abord, à la place d'envoyer un message dans un salon, il faudra cliquer sur un bouton pour ouvrir un formulaire (ou _modal_) permettant de renseigner un titre et une description, respectivement de minimum 10 et 30 caractères et de maxium 80 et 3072 caractères. Une fois le formulaire rempli, un message est généré dans le salon des suggestions avec le titre et le contenu de la suggestion. Un fil de discussion est automatiquement créé et des réactions sont ajoutées au message initial (cette partie reste donc inchangée).

- Un administrateur peut voter pour une suggestion sans que celle-ci ne soit acceptée, refusée ou clôturée. Des commandes ont donc été créées à cette effet. Elles sont à effectuer au sein du fil créé pour la suggestion que l'on veut fermer. Lorsqu'une telle commande est effectuée, l'auteur originel de la suggestion est alors mentionné dans le fil de discussion qui se retrouve alors bloqué et archivé, mais toujours consultable.

- Une raison peut être donnée, ou non, au bon vouloir de l'administrateur qui aura exécuté la commande de fermeture d'une suggestion. Cette raison sera alors mis dans le message initial de la suggestion.

- Le résultat des votes apparaît dans l'embed (inchangé) et les réactions sont supprimées.

La pagination de la liste des suggestions est prévue mais pas encore implémentée dans cette branche.


L'acceptation de cette PR engendrera une rupture avec l'ancien système, si bien que les suggestions en cours doivent être traitées avant le passage vers le système proposé ici. Les suggestions peuvent aussi être supprimées et remise dans le nouveau système.

La base de données devra être modifiée puisque de nouveaux champs (quatre) sont demandés pour les suggestions et un nouveau pour les guildes.

Le champ `guilds.ID.channels.suggestion` n'est plus obligatoire dans la configuration car maintenant dans la base de donnée.

Dans l'idéal le salon `suggestions` devra bloquer l'envoi de messages et la création de fils de discussion privés comme publics.